### PR TITLE
Add TF-IDF search engine with interactive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ This repository contains a simple offline search engine implemented in Python.
 ## search_engine.py
 
 ```
-usage: python search_engine.py <documents_directory>
+usage: python search_engine.py [-k LIMIT] directory
 ```
 
-The script indexes all `.txt` files in the specified directory and allows you to search for documents containing the query terms. Queries are entered interactively; entering a blank line exits the program.
+The script recursively indexes all `.txt` files in the specified directory, builds a TF-IDF index, and lets you search for relevant documents. Queries are entered interactively; enter `:list` to see indexed files, `:quit` or a blank line to exit. Use `-k`/`--limit` to adjust how many results are shown (default 10).
 
-Make sure the directory exists and contains some text files before running the script. For example:
+Quick start example:
 
 ```bash
-mkdir docs
+mkdir -p docs/notes
 echo "hello world" > docs/example.txt
+echo "another document about search" > docs/notes/search.txt
 python3 search_engine.py docs
 ```

--- a/search_engine.py
+++ b/search_engine.py
@@ -1,71 +1,178 @@
-# Simple offline search engine
-import os
-import sys
+"""Offline TF-IDF search engine for local text files."""
+from __future__ import annotations
+
+import argparse
+import math
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
 import re
-from collections import defaultdict, Counter
 
-def tokenize(text):
-    # Split on non-word characters
-    return re.findall(r"\b\w+\b", text.lower())
 
-def build_index(directory):
-    index = defaultdict(Counter)
-    documents = {}
-    for filename in os.listdir(directory):
-        path = os.path.join(directory, filename)
-        if os.path.isfile(path) and filename.endswith('.txt'):
-            with open(path, 'r', encoding='utf-8', errors='ignore') as f:
-                text = f.read()
+WORD_RE = re.compile(r"\b\w+\b")
+
+
+def tokenize(text: str) -> List[str]:
+    """Split a string into lowercase word tokens."""
+    return WORD_RE.findall(text.lower())
+
+
+@dataclass
+class DocumentRecord:
+    """Metadata and cached content for a document."""
+
+    name: str
+    path: Path
+    preview: str
+
+
+class SearchEngine:
+    """Indexes `.txt` files and performs cosine-similarity search."""
+
+    def __init__(self, directory: Path):
+        self.directory = directory
+        self.documents: Dict[Path, DocumentRecord] = {}
+        self.term_idf: Dict[str, float] = {}
+        self.doc_vectors: Dict[Path, Dict[str, float]] = {}
+        self.doc_norms: Dict[Path, float] = {}
+
+    def build_index(self) -> None:
+        """Index every `.txt` file under ``directory`` recursively."""
+        raw_term_counts: Dict[Path, Counter[str]] = {}
+        document_frequency: Counter[str] = Counter()
+
+        for path in sorted(self.directory.rglob("*.txt")):
+            if not path.is_file():
+                continue
+            text = path.read_text(encoding="utf-8", errors="ignore")
             tokens = tokenize(text)
-            documents[filename] = tokens
-            for token in tokens:
-                index[token][filename] += 1
-    return index, documents
+            if not tokens:
+                continue
 
-def search(index, query_tokens):
-    if not query_tokens:
-        return []
-    candidates = None
-    for token in query_tokens:
-        docs = set(index.get(token, []))
-        if candidates is None:
-            candidates = docs
-        else:
-            candidates &= docs
-        if not candidates:
-            break
-    if not candidates:
-        return []
-    # Rank by sum of token counts
-    ranked = []
-    for doc in candidates:
-        score = sum(index[token][doc] for token in query_tokens)
-        ranked.append((score, doc))
-    ranked.sort(reverse=True)
-    return [doc for score, doc in ranked]
+            counts = Counter(tokens)
+            raw_term_counts[path] = counts
+            document_frequency.update(counts.keys())
+            preview = text.strip().splitlines()[0][:200] if text.strip() else ""
+            self.documents[path] = DocumentRecord(name=path.name, path=path, preview=preview)
 
-def main():
-    if len(sys.argv) != 2:
-        print('Usage: python search_engine.py <documents_directory>')
-        sys.exit(1)
-    directory = sys.argv[1]
-    if not os.path.isdir(directory):
-        print(f"Error: directory '{directory}' does not exist")
-        sys.exit(1)
-    index, _ = build_index(directory)
-    print('Index built. Enter search queries (blank line to exit).')
-    while True:
-        query = input('> ').strip()
-        if not query:
-            break
+        num_docs = len(raw_term_counts)
+        if num_docs == 0:
+            return
+
+        # Calculate IDF with smoothing to avoid division by zero.
+        self.term_idf = {
+            term: math.log((1 + num_docs) / (1 + freq)) + 1
+            for term, freq in document_frequency.items()
+        }
+
+        for path, counts in raw_term_counts.items():
+            doc_len = sum(counts.values())
+            if doc_len == 0:
+                continue
+
+            vector: Dict[str, float] = {}
+            for term, count in counts.items():
+                tf = count / doc_len
+                idf = self.term_idf.get(term, 0.0)
+                vector[term] = tf * idf
+
+            norm = math.sqrt(sum(weight * weight for weight in vector.values())) or 1e-9
+            self.doc_vectors[path] = vector
+            self.doc_norms[path] = norm
+
+    def search(self, query: str, limit: int = 10) -> List[Tuple[DocumentRecord, float]]:
+        """Search for a query string and return ranked results."""
         tokens = tokenize(query)
-        results = search(index, tokens)
-        if results:
-            print('Results:')
-            for doc in results:
-                print(' -', doc)
-        else:
-            print('No results found.')
+        if not tokens:
+            return []
+        if not self.doc_vectors:
+            return []
 
-if __name__ == '__main__':
+        query_counts = Counter(tokens)
+        query_len = sum(query_counts.values())
+        query_vector: Dict[str, float] = {}
+        for term, count in query_counts.items():
+            idf = self.term_idf.get(term, 0.0)
+            query_vector[term] = (count / query_len) * idf
+
+        query_norm = math.sqrt(sum(weight * weight for weight in query_vector.values())) or 1e-9
+
+        scores: List[Tuple[float, Path]] = []
+        for path, doc_vector in self.doc_vectors.items():
+            numerator = sum(query_vector.get(term, 0.0) * weight for term, weight in doc_vector.items())
+            score = numerator / (self.doc_norms[path] * query_norm)
+            if score > 0:
+                scores.append((score, path))
+
+        scores.sort(reverse=True)
+        results = []
+        for score, path in scores[:limit]:
+            results.append((self.documents[path], score))
+        return results
+
+    def list_documents(self) -> List[DocumentRecord]:
+        return [self.documents[path] for path in sorted(self.documents)]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Offline TF-IDF search engine for text files")
+    parser.add_argument(
+        "directory",
+        type=Path,
+        help="Directory containing .txt documents to index (searched recursively)",
+    )
+    parser.add_argument(
+        "-k",
+        "--limit",
+        type=int,
+        default=10,
+        help="Number of results to return for each query",
+    )
+    return parser.parse_args()
+
+
+def interactive_loop(engine: SearchEngine, limit: int) -> None:
+    print("Index built. Enter search queries (blank line to exit).")
+    print("Commands: :list to view indexed files, :quit to exit.")
+    while True:
+        query = input("> ").strip()
+        if not query or query == ":quit":
+            break
+        if query == ":list":
+            docs = engine.list_documents()
+            if not docs:
+                print("No documents indexed.")
+            else:
+                for doc in docs:
+                    print(f" - {doc.name}")
+            continue
+
+        results = engine.search(query, limit=limit)
+        if not results:
+            print("No results found.")
+            continue
+
+        print("Results:")
+        for doc, score in results:
+            preview = f" — {doc.preview}" if doc.preview else ""
+            print(f" - {doc.name} (score: {score:.3f}){preview}")
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.directory.exists() or not args.directory.is_dir():
+        raise SystemExit(f"Error: directory '{args.directory}' does not exist or is not a directory")
+
+    engine = SearchEngine(args.directory)
+    engine.build_index()
+
+    if not engine.documents:
+        print("No .txt files found to index. Exiting.")
+        return
+
+    interactive_loop(engine, args.limit)
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the simple keyword matcher with a TF-IDF search engine and recursive indexing of .txt files
- add interactive commands to list indexed documents and configurable result limits
- update README with refreshed usage instructions and quick start example

## Testing
- python search_engine.py --help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692493d303808325a112fcab65573e02)